### PR TITLE
Add README.md with instructions on how to handle the split archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+This project is stored as a split 7-Zip archive due to file size limits on GitHub. In order to access the project, you need to download and extract all parts of the .7z archive.
+
+Steps to Extract the Project
+1. Download All Parts
+
+Make sure to download all the parts of the split archive:
+* splitted_project_road_vignette_analytics.7z.001
+* splitted_project_road_vignette_analytics.7z.002
+* splitted_project_road_vignette_analytics.7z.003
+* splitted_project_road_vignette_analytics.7z.004
+* splitted_project_road_vignette_analytics.7z.005
+
+All the parts must be in the same directory before you proceed with extraction.
+
+2. Install 7-Zip (if necessary)
+
+If you don’t already have 7-Zip installed, you can download it from the official website: https://www.7-zip.org/download.html
+
+3. Extract the Archive
+
+Start extraction only from splitted_project_road_vignette_analytics.7z.001 The software will automatically extract the contents from all parts (you don't need to extract .002, .003, etc. manually). The extraction process will assemble the files back together.
+
+4. Access the Project Files
+
+After extraction, you will see the full project structure along with the original README.md and the rest of the project files.


### PR DESCRIPTION
# RoadVignetteAnalytics Project - Split Archive Instructions

This project has been split into multiple `.7z` archive parts due to file size constraints. To use the project, you will need to combine and extract the parts.